### PR TITLE
Fix plugin.xml for cordova-android 7.x

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -18,7 +18,7 @@
 
     <!-- android -->
     <platform name="android">
-        <config-file target="config.xml" parent="/*">
+        <config-file target="res/xml/config.xml" parent="/*">
             <feature name="Migration" >
                 <param name="android-package" value="cordova.plugins.crosswalk.Migration"/>
                 <param name="onload" value="true" />


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation  changes
- [ ] Other... Please describe:

<!-- Fill out the relevant sections below and delete irrelevant sections. -->

## PR Checklist
For bug fixes / features, please check if your PR fulfills the following requirements:

- [x] Testing has been carried out for the changes have been added
- [ ] Regression testing has been carried out for existing functionality
- [ ] Docs have been added / updated

## What is the purpose of this PR?
This PR fixes the installation of the plugin for cordova-android 7.x. Wrong `target` for config.xml causes installation error on android 7.x.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## What testing has been done on the changes in the PR?
I have tested the plugin now correctly installs itself on cordova-android 7.x.
I haven't tested an installation on cordova-android 6.x but this fix follows cordova standard plugins so it shouldn't break anything.

## What testing has been done on existing functionality?
NA

## Other information